### PR TITLE
Stop stream tracks after stopping the recording

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const recordAudio = () =>
           const audioUrl = URL.createObjectURL(audioBlob);
           const audio = new Audio(audioUrl);
           const play = () => audio.play();
+          stream.getTracks().forEach((track) => track.stop());
           resolve({ audioBlob, audioUrl, play });
         });
 


### PR DESCRIPTION
Before this change, the browser would think you were still recording even after you stopped recording.
See: https://github.com/bryanjenningz/record-audio/issues/16

This change fixes that problem by stopping the stream tracks when the user stops recording.

How to test this change:
* Open the index.html file in your browser
* Click on the "Start recording..." button
* Allow the browser to record by accepting the permission dialog
* Wait 6 seconds for the recording to record, stop, then play
* Confirm that there is no longer a microphone icon in the browser tab after the recording is done